### PR TITLE
App close logic

### DIFF
--- a/app/src/main/java/se2/carcassonne/api/PlayerApi.java
+++ b/app/src/main/java/se2/carcassonne/api/PlayerApi.java
@@ -21,4 +21,12 @@ public class PlayerApi {
             e.printStackTrace();
         }
     }
+
+    public void deleteUser(Player player) {
+        try {
+            webSocketClient.sendMessage("/app/player-delete", objectMapper.writeValueAsString(player));
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/app/src/main/java/se2/carcassonne/helper/mapper/MapperHelper.java
+++ b/app/src/main/java/se2/carcassonne/helper/mapper/MapperHelper.java
@@ -8,9 +8,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 
 import se2.carcassonne.model.Lobby;
+import se2.carcassonne.model.Player;
 
 public class MapperHelper {
-    // PlayerMapping
+    public Player getPlayer(String playerStringAsJson) {
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode player = null;
+        try {
+            player = mapper.readTree(playerStringAsJson);
+            return mapper.treeToValue(player, Player.class);
+        } catch (JsonProcessingException e) {
+            Log.e("Mapping Exception", "Error processing JSON in getPlayer: " + e.getMessage());
+            return null;
+        }
+    }
+
     public long getPlayerId(String playerStringAsJson) {
         ObjectMapper mapper = new ObjectMapper();
         JsonNode playerId = null;

--- a/app/src/main/java/se2/carcassonne/repository/PlayerRepository.java
+++ b/app/src/main/java/se2/carcassonne/repository/PlayerRepository.java
@@ -1,5 +1,7 @@
 package se2.carcassonne.repository;
 
+import android.util.Log;
+
 import androidx.lifecycle.MutableLiveData;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -69,6 +71,23 @@ public class PlayerRepository {
 
     public Player getCurrentPlayer() {
         return currentPlayer;
+    }
+
+    public void deletePlayer(Player player) {
+        webSocketClient.subscribeToQueue("/user/queue/response", this::deletePlayerMessageReceived);
+        webSocketClient.subscribeToQueue("/user/queue/errors", this::createPlayerMessageReceived);
+        playerApi.deleteUser(player);
+    }
+
+    private void deletePlayerMessageReceived(String message) {
+        webSocketClient.unsubscribe("/user/queue/response");
+        webSocketClient.unsubscribe("/user/queue/errors");
+
+        if(message.equals("103")) {
+            Log.d("onDelete", "Player deleted");
+        } else if (message.contains("ERROR")) {
+            Log.d("onDelete", "Error while deleting");
+        }
     }
 
     public MutableLiveData<String> getCreatePlayerLiveData() {

--- a/app/src/main/java/se2/carcassonne/ui/HomeActivity.java
+++ b/app/src/main/java/se2/carcassonne/ui/HomeActivity.java
@@ -43,6 +43,8 @@ public class HomeActivity extends AppCompatActivity {
         });
     }
 
+
+
     private void showChooseUsernameDialog() {
         FragmentManager fragmentManager = getSupportFragmentManager();
         ChooseUsernameDialogFragment dialogFragment = new ChooseUsernameDialogFragment(playerViewModel);

--- a/app/src/main/java/se2/carcassonne/ui/InLobbyActivity.java
+++ b/app/src/main/java/se2/carcassonne/ui/InLobbyActivity.java
@@ -79,6 +79,7 @@ public class InLobbyActivity extends AppCompatActivity {
     protected void onDestroy() {
         lobbyViewmodel.getPlayerInLobbyReceivesUpdatedLobbyLiveData().setValue(null);
         lobbyViewmodel.getPlayerLeavesLobbyLiveData().setValue(null);
+        lobbyViewmodel.leaveLobby();
         super.onDestroy();
     }
 }

--- a/app/src/main/java/se2/carcassonne/ui/StartupActivity.java
+++ b/app/src/main/java/se2/carcassonne/ui/StartupActivity.java
@@ -15,6 +15,7 @@ import se2.carcassonne.helper.animation.AnimationHelper;
 import se2.carcassonne.helper.network.WebSocketClient;
 import se2.carcassonne.helper.resize.FullscreenHelper;
 import se2.carcassonne.model.Player;
+import se2.carcassonne.repository.PlayerRepository;
 
 public class StartupActivity extends AppCompatActivity {
     StartupActivityBinding binding;

--- a/app/src/main/java/se2/carcassonne/ui/StartupActivity.java
+++ b/app/src/main/java/se2/carcassonne/ui/StartupActivity.java
@@ -14,9 +14,11 @@ import se2.carcassonne.databinding.StartupActivityBinding;
 import se2.carcassonne.helper.animation.AnimationHelper;
 import se2.carcassonne.helper.network.WebSocketClient;
 import se2.carcassonne.helper.resize.FullscreenHelper;
+import se2.carcassonne.model.Player;
 
 public class StartupActivity extends AppCompatActivity {
     StartupActivityBinding binding;
+    PlayerRepository repository = PlayerRepository.getInstance();
     private final WebSocketClient webSocketClient = WebSocketClient.getInstance();
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -60,4 +62,12 @@ public class StartupActivity extends AppCompatActivity {
         });
 
     }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        Player player = PlayerRepository.getInstance().getCurrentPlayer();
+        if(player != null) repository.deletePlayer(player);
+    }
+
 }


### PR DESCRIPTION
Added logic for player deletion and functionality to delete a player when the app exits. The following things are handled now:
- If the app exits the player which was created will be deleted from the backend
- If the player was already part of a lobby he will be removed from the lobby
- If the player was the last one in the lobby, the lobby is deleted too