### PR TITLE
fix: eaveLobby call in onDestroy leading to null pointers - Button Rotation

### DIFF
--- a/app/src/main/java/se2/carcassonne/ui/GameBoardActivity.java
+++ b/app/src/main/java/se2/carcassonne/ui/GameBoardActivity.java
@@ -262,7 +262,7 @@ public class GameBoardActivity extends AppCompatActivity {
     private void setupRotationButtons() {
         final ImageRotator imageRotator = new ImageRotator(previewTileToPlace);
         binding.buttonRotateClockwise.setOnClickListener(v -> {
-            if (gameboardAdapter.isYourTurn()) {
+            if (gameboardAdapter.isYourTurn() && gameboardAdapter.isCanPlaceTile()) {
                 imageRotator.rotateRight();
                 tileToPlace.rotate(true);
                 gameboardAdapter.setCurrentTileRotation(tileToPlace);
@@ -270,7 +270,7 @@ public class GameBoardActivity extends AppCompatActivity {
         });
 
         binding.buttonRotateCounterClockwise.setOnClickListener(v -> {
-            if (gameboardAdapter.isYourTurn()) {
+            if (gameboardAdapter.isYourTurn() && gameboardAdapter.isCanPlaceTile()) {
                 imageRotator.rotateLeft();
                 tileToPlace.rotate(false);
                 gameboardAdapter.setCurrentTileRotation(tileToPlace);

--- a/app/src/main/java/se2/carcassonne/ui/InLobbyActivity.java
+++ b/app/src/main/java/se2/carcassonne/ui/InLobbyActivity.java
@@ -88,7 +88,6 @@ public class InLobbyActivity extends AppCompatActivity {
     protected void onDestroy() {
         lobbyViewmodel.getPlayerInLobbyReceivesUpdatedLobbyLiveData().setValue(null);
         lobbyViewmodel.getPlayerLeavesLobbyLiveData().setValue(null);
-        lobbyViewmodel.leaveLobby();
         super.onDestroy();
     }
 }


### PR DESCRIPTION
Additionally removed the ability to rotate the button after you placed a tile