### PR TITLE
fix: button text startGame is no more visible, after all except from …

### DIFF
--- a/app/src/main/java/se2/carcassonne/ui/InLobbyActivity.java
+++ b/app/src/main/java/se2/carcassonne/ui/InLobbyActivity.java
@@ -74,6 +74,7 @@ public class InLobbyActivity extends AppCompatActivity {
                 adapter.updateGameLobby(newGameLobby);
             } else if (newGameLobby != null) {
                 adapter.updateGameLobby(newGameLobby.split("\\|")[1]);
+                binding.gameLobbyStartGameBtn.clearAnimation();
                 binding.gameLobbyStartGameBtn.setVisibility(View.GONE);
             }
         });


### PR DESCRIPTION
fix: when one player leave the lobby the button start game is not visible anymore