### PR TITLE
bugfix: Check for no valid tile placement positions

### DIFF
--- a/app/src/main/java/se2/carcassonne/model/GameBoard.java
+++ b/app/src/main/java/se2/carcassonne/model/GameBoard.java
@@ -117,6 +117,20 @@ public class GameBoard {
         return validPositions;
     }
 
+    public boolean hasValidPositionForAnyRotation(Tile tile) {
+        // Check for all rotations if there is a valid position
+        for (int rotation = 0; rotation < 4; rotation++) {
+            tile.setRotation(rotation);
+            ArrayList<Coordinates> validPositions = highlightValidPositions(tile);
+            if (!validPositions.isEmpty()) {
+                tile.setRotation(0);
+                return true;
+            }
+        }
+        tile.setRotation(0);
+        return false;
+    }
+
     private boolean validPlacementForTileWithCurrentRotation(Tile tileToPlace, Coordinates position) {
         int x = position.getXPosition();
         int y = position.getYPosition();

--- a/app/src/main/java/se2/carcassonne/ui/GameBoardActivity.java
+++ b/app/src/main/java/se2/carcassonne/ui/GameBoardActivity.java
@@ -3,6 +3,8 @@ package se2.carcassonne.ui;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.os.Vibrator;
 import android.os.VibratorManager;
 import android.view.View;
@@ -131,19 +133,32 @@ public class GameBoardActivity extends AppCompatActivity {
                     vibrator.vibrate(500); // for 500 ms
                 }
                 tileToPlace = gameBoard.getAllTiles().get(Math.toIntExact(nextTurn.getTileId()));
-                previewTileToPlace.setRotation(0);
-                gameboardAdapter.setCanPlaceTile(true);
-                gameboardAdapter.setYourTurn(true);
-                gameboardAdapter.setTileToPlace(tileToPlace);
-                previewTileToPlace.setImageResource(
-                        getResources().getIdentifier(tileToPlace.getImageName() + "_0", "drawable", getPackageName()));
-                binding.buttonConfirmTilePlacement.setVisibility(View.VISIBLE);
-                binding.buttonRotateClockwise.setVisibility(View.VISIBLE);
-                binding.buttonRotateCounterClockwise.setVisibility(View.VISIBLE);
-                binding.previewTileToPlace.setVisibility(View.VISIBLE);
-                binding.backgroundRight.setVisibility(View.VISIBLE);
+                if (!gameBoard.hasValidPositionForAnyRotation(tileToPlace)) {
+                    previewTileToPlace.setImageResource(
+                            getResources().getIdentifier(tileToPlace.getImageName() + "_0", "drawable", getPackageName()));
 
-                moveButtonsLeft();
+                    // Display a Toast or some notification to the user
+                    Toast.makeText(this, "No valid positions to place tile. Next turn will start shortly.", Toast.LENGTH_SHORT).show();
+
+                    // Handler to add a delay before the next turn starts
+                    new Handler(Looper.getMainLooper()).postDelayed(this::confirmNextTurnToStart, 3000); // 3000 milliseconds == 3 seconds
+                } else {
+                    previewTileToPlace.setRotation(0);
+                    gameboardAdapter.setCanPlaceTile(true);
+                    gameboardAdapter.setYourTurn(true);
+                    gameboardAdapter.setTileToPlace(tileToPlace);
+                    previewTileToPlace.setImageResource(
+                            getResources().getIdentifier(tileToPlace.getImageName() + "_0", "drawable", getPackageName()));
+                    binding.buttonConfirmTilePlacement.setVisibility(View.VISIBLE);
+                    binding.buttonRotateClockwise.setVisibility(View.VISIBLE);
+                    binding.buttonRotateCounterClockwise.setVisibility(View.VISIBLE);
+                    binding.previewTileToPlace.setVisibility(View.VISIBLE);
+                    binding.backgroundRight.setVisibility(View.VISIBLE);
+
+                    moveButtonsLeft();
+                }
+
+
             } else {
                 tileToPlace = null;
                 gameboardAdapter.setYourTurn(false);

--- a/app/src/test/java/GameBoardModelTests.java
+++ b/app/src/test/java/GameBoardModelTests.java
@@ -83,4 +83,19 @@ public class GameBoardModelTests {
         assertTrue(gameBoard.getPlaceablePositions().contains(new Coordinates(12, 13))); // south of new tile
         assertTrue(gameBoard.getPlaceablePositions().contains(new Coordinates(11, 12))); // west of new tile
     }
+
+    @Test
+    public void noValidTilePlacementForAnyRotation() {
+        GameBoard gameBoard = new GameBoard();
+        gameBoard.placeTile(gameBoard.getAllTiles().get(1), new Coordinates(13, 12)); // place the tile east from start tile
+        gameBoard.placeTile(gameBoard.getAllTiles().get(39), new Coordinates(11, 12)); // place the tile west from start tile
+        gameBoard.placeTile(gameBoard.getAllTiles().get(1), new Coordinates(12, 13)); // place the tile south from start tile
+        assertFalse(gameBoard.hasValidPositionForAnyRotation(gameBoard.getAllTiles().get(45))); // check if there is a valid position for any rotation
+    }
+
+    @Test
+    public void validTilePlacementsForAnyRotation() {
+        GameBoard gameBoard = new GameBoard();
+        assertTrue(gameBoard.hasValidPositionForAnyRotation(gameBoard.getAllTiles().get(1))); // check if there is a valid position for any rotation
+    }
 }


### PR DESCRIPTION
User is no longer stuck in the tile placement screen if he gets a tile that cannot be placed to any other tile